### PR TITLE
Add support for new filenames for May 20, 2020 patch to Python script

### DIFF
--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -739,7 +739,7 @@ if __name__ == '__main__':
     parser.add_argument('-l', '--log_file',
         help=f'Log filename to process. If not specified, will try one of {POSSIBLE_CURRENT_FILEPATHS}')
     parser.add_argument('--host', default=API_ENDPOINT,
-        help=f'Host to submit requsts to. If not specified, will use {API_ENDPOINT}')
+        help=f'Host to submit requests to. If not specified, will use {API_ENDPOINT}')
     parser.add_argument('--once', action='store_true',
         help='Whether to stop after parsing the file once (default is to continue waiting for updates to the file)')
 

--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -37,7 +37,7 @@ logging.basicConfig(
 CLIENT_VERSION = '0.1.8'
 
 LOG_ROOT = os.path.join('users',getpass.getuser(),'AppData','LocalLow','Wizards Of The Coast','MTGA')
-CURRENT_LOG_PATH = os.path.join(LOG_ROOT, 'output_log.txt')
+CURRENT_LOG_PATH = os.path.join(LOG_ROOT, 'Player.log')
 POSSIBLE_ROOTS = (
     # Windows
     'C:/',

--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -14,6 +14,7 @@ details.
 import datetime
 import json
 import getpass
+import itertools
 import logging
 import os
 import os.path
@@ -35,16 +36,19 @@ logging.basicConfig(
 
 CLIENT_VERSION = '0.1.8'
 
-PATH_ON_DRIVE = os.path.join('users',getpass.getuser(),'AppData','LocalLow','Wizards Of The Coast','MTGA','output_log.txt')
-POSSIBLE_FILEPATHS = (
+LOG_ROOT = os.path.join('users',getpass.getuser(),'AppData','LocalLow','Wizards Of The Coast','MTGA')
+CURRENT_LOG_PATH = os.path.join(LOG_ROOT, 'output_log.txt')
+POSSIBLE_ROOTS = (
     # Windows
-    os.path.join('C:/',PATH_ON_DRIVE),
-    os.path.join('D:/',PATH_ON_DRIVE),
+    'C:/',
+    'D:/',
     # Lutris
-    os.path.join(os.path.expanduser('~'),'Games','magic-the-gathering-arena','drive_c',PATH_ON_DRIVE),
+    os.path.join(os.path.expanduser('~'),'Games','magic-the-gathering-arena','drive_c'),
     # Wine
-    os.path.join(os.path.expanduser('~'),'.wine','drive_c',PATH_ON_DRIVE),
+    os.path.join(os.path.expanduser('~'),'.wine','drive_c'),
 )
+
+POSSIBLE_CURRENT_FILEPATHS = map(lambda root_and_path: os.path.join(*root_and_path), itertools.product(POSSIBLE_ROOTS, (CURRENT_LOG_PATH, )))
 
 CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.mtga_follower.ini')
 
@@ -733,7 +737,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='MTGA log follower')
     parser.add_argument('-l', '--log_file',
-        help=f'Log filename to process. If not specified, will try one of {POSSIBLE_FILEPATHS}')
+        help=f'Log filename to process. If not specified, will try one of {POSSIBLE_CURRENT_FILEPATHS}')
     parser.add_argument('--host', default=API_ENDPOINT,
         help=f'Host to submit requsts to. If not specified, will use {API_ENDPOINT}')
     parser.add_argument('--once', action='store_true',
@@ -746,7 +750,7 @@ if __name__ == '__main__':
     token = get_client_token()
     logging.info(f'Using token {token}')
 
-    filepaths = POSSIBLE_FILEPATHS
+    filepaths = POSSIBLE_CURRENT_FILEPATHS
     if args.log_file is not None:
         filepaths = (args.log_file, )
 


### PR DESCRIPTION
Thank you so much for creating this great service! 17lands is the only MTGA Tracker that works with my Ubuntu + Lutris setup. Thank you for adding support for Lutris/Wine paths out of the box =)

This PR brings the Python script up to date with the May 20, 2020 Arena patch which changed the logfile names. I dropped support for the old `output_log.txt` filename entirely.

I also added a quality-of-life feature that automatically parses the `Player-prev.log` file once at startup before starting to tail `Player.log`. This can potentially catch a user up if they forgot to run the script during a previous Arena session or if they didn't realize they needed to upgrade the script for the new patch and continued to play with the old script for a while. Not sure if this feature is desired as it will add additional load on the 17lands server. Would welcome any feedback.