### PR TITLE
Include emotes in replay history

### DIFF
--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -381,6 +381,8 @@ class Follower:
                 self.__handle_gre_to_client_message(message)
         elif json_value_matches('ClientToMatchServiceMessageType_ClientToGREMessage', ['clientToMatchServiceMessageType'], json_obj):
             self.__handle_client_to_gre_message(json_obj.get('payload', {}))
+        elif json_value_matches('ClientToMatchServiceMessageType_ClientToGREUIMessage', ['clientToMatchServiceMessageType'], json_obj):
+            self.__handle_client_to_gre_ui_message(json_obj.get('payload', {}))
         elif 'limitedStep' in json_obj:
             self.__handle_self_rank_info(json_obj)
         elif 'opponentRankingClass' in json_obj:
@@ -430,6 +432,8 @@ class Follower:
         # Add to game history before processing the messsage, since we may submit the game right away.
         if self.history_enabled:
             if message_blob['type'] in ['GREMessageType_QueuedGameStateMessage', 'GREMessageType_GameStateMessage']:
+                self.game_history_events.append(message_blob)
+            elif message_blob['type'] == 'GREMessageType_UIMessage' and 'onChat' in message_blob['uiMessage']:
                 self.game_history_events.append(message_blob)
 
         if message_blob['type'] == 'GREMessageType_GameStateMessage':
@@ -490,6 +494,11 @@ class Follower:
             }
             logger.info(f'Deck submission via __handle_client_to_gre_message: {deck}')
             response = self.__retry_post(f'{self.host}/{ENDPOINT_DECK_SUBMISSION}', blob=deck)
+
+    def __handle_client_to_gre_ui_message(self, payload):
+        if self.history_enabled:
+            if 'onChat' in payload['uiMessage']:
+                self.game_history_events.append(payload)
 
     def __maybe_handle_game_over_stage(self, system_seat_ids, game_state_message):
         game_info = game_state_message.get('gameInfo', {})

--- a/src/cs/mtga-log-client/MainWindow.xaml.cs
+++ b/src/cs/mtga-log-client/MainWindow.xaml.cs
@@ -1914,7 +1914,7 @@ namespace mtga_log_client
             }
             else if (message["type"].Value<String>() == "GREMessageType_UIMessage")
             {
-                if (message.ContainsKey("uiMessage"))
+                if (message.Value<JObject>().ContainsKey("uiMessage"))
                 {
                     var uiMessage = message["uiMessage"].Value<JObject>();
                     if (uiMessage.ContainsKey("onChat"))


### PR DESCRIPTION
Not sure if we want to display emotes in the UI yet, but include the data just for fun. The messages are also quite tiny so won't bloat the history up by much.

```
[UnityCrossThreadLogger]3/7/2021 12:59:18 PM: Match to EDITFNQ6UNHDXLFKSPAWPJVBHY: GreToClientEvent
{ "transactionId": "31eaa357-0e5e-4251-a761-335708b2d42a", "timestamp": "637507475589906310", "greToClientEvent": { "greToClientMessages": [ { "type": "GREMessageType_UIMessage", "systemSeatIds": [ 2 ], "uiMessage": { "seatIds": [ 1 ], "onChat": { "text": "{\"Id\":\"Phrase_Basic_GoodGame\",\"LocalizationKey\":\"DuelScene/Emotes/GoodGame\",\"Category\":\"GoodGame\"}" } } } ] } }
```

```
[UnityCrossThreadLogger]3/7/2021 12:59:20 PM: EDITFNQ6UNHDXLFKSPAWPJVBHY to Match: ClientToMatchServiceMessageType_ClientToGREUIMessage
{
  "requestId": 745,
  "clientToMatchServiceMessageType": "ClientToMatchServiceMessageType_ClientToGREUIMessage",
  "timestamp": "637507475607873850",
  "transactionId": "e004be7a-1eb4-45b9-a537-e7347a8e41d3",
  "payload": {
    "type": "ClientMessageType_UIMessage",
    "systemSeatId": 2,
    "uiMessage": {
      "seatIds": [
        1
      ],
      "onChat": {                                                                                                                                                                    
        "text": "{\"Id\":\"Phrase_Basic_GoodGame\",\"LocalizationKey\":\"DuelScene/Emotes/GoodGame\",\"Category\":\"GoodGame\"}"
      }
    }
  }
}
```