### PR TITLE
Add WINEPREFIX as possible root

### DIFF
--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -77,6 +77,8 @@ POSSIBLE_ROOTS = (
     os.path.join(os.path.expanduser('~'), 'Games', 'magic-the-gathering-arena', 'drive_c', WINDOWS_LOG_ROOT),
     # Wine
     os.path.join(os.path.expanduser('~'), '.wine', 'drive_c', WINDOWS_LOG_ROOT),
+    # WINEPREFIX
+    os.path.join(os.environ.get('WINEPREFIX'), 'drive_c', WINDOWS_LOG_ROOT),
     # OSX
     os.path.join(os.path.expanduser('~'), OSX_LOG_ROOT),
 )

--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -76,9 +76,7 @@ POSSIBLE_ROOTS = (
     # Lutris
     os.path.join(os.path.expanduser('~'), 'Games', 'magic-the-gathering-arena', 'drive_c', WINDOWS_LOG_ROOT),
     # Wine
-    os.path.join(os.path.expanduser('~'), '.wine', 'drive_c', WINDOWS_LOG_ROOT),
-    # WINEPREFIX
-    os.path.join(os.environ.get('WINEPREFIX'), 'drive_c', WINDOWS_LOG_ROOT),
+    os.path.join(os.environ.get('WINEPREFIX', os.path.join(os.path.expanduser('~'), '.wine')), 'drive_c', WINDOWS_LOG_ROOT),
     # OSX
     os.path.join(os.path.expanduser('~'), OSX_LOG_ROOT),
 )


### PR DESCRIPTION
Allows to call the tool with e.g.

```
WINEPREFIX=~/.local/share/wineprefixes/MTGA seventeenlands
```

so that it finds the Arena logs in a custom WINEPREFIX instead of `~/.wine`.

Closes #94 