### PR TITLE
German locale: Yet another time format

### DIFF
--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -86,7 +86,7 @@ POSSIBLE_PREVIOUS_FILEPATHS = list(map(lambda root_and_path: os.path.join(*root_
 
 CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.mtga_follower.ini')
 
-LOG_START_REGEX_TIMED = re.compile(r'^\[(UnityCrossThreadLogger|Client GRE)\]([\d:/ -]+(AM|PM)?)')
+LOG_START_REGEX_TIMED = re.compile(r'^\[(UnityCrossThreadLogger|Client GRE)\]([\d:/ .-]+(AM|PM)?)')
 LOG_START_REGEX_UNTIMED = re.compile(r'^\[(UnityCrossThreadLogger|Client GRE)\]')
 TIMESTAMP_REGEX = re.compile('^([\\d/.-]+[ T][\\d]+:[\\d]+:[\\d]+( AM| PM)?)')
 STRIPPED_TIMESTAMP_REGEX = re.compile('^(.*?)[: /]*$')
@@ -102,6 +102,7 @@ TIME_FORMATS = (
     '%Y/%m/%d %I:%M:%S %p',
     '%Y/%m/%d %H:%M:%S',
     '%d/%m/%Y %H:%M:%S',
+    '%d.%m.%Y %H:%M:%S'
 )
 OUTPUT_TIME_FORMAT = '%Y%m%d%H%M%S'
 


### PR DESCRIPTION
I changed the LOG_START_REGEX_TIMED and TIME_FORMATS variables so that log files from a client that is set to German can be parsed.

An example German time string is "12.05.2021 19:35:36".