### PR TITLE
Make log timestamp parsing reject --

### DIFF
--- a/mtga_follower.py
+++ b/mtga_follower.py
@@ -90,7 +90,7 @@ POSSIBLE_PREVIOUS_FILEPATHS = list(map(lambda root_and_path: os.path.join(*root_
 
 CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.mtga_follower.ini')
 
-LOG_START_REGEX_TIMED = re.compile(r'^\[(UnityCrossThreadLogger|Client GRE)\]([\d:/ .-]+(AM|PM)?)')
+LOG_START_REGEX_TIMED = re.compile(r'^\[(UnityCrossThreadLogger|Client GRE)\](\d[\d:/ .-]+(AM|PM)?)')
 LOG_START_REGEX_UNTIMED = re.compile(r'^\[(UnityCrossThreadLogger|Client GRE)\]')
 TIMESTAMP_REGEX = re.compile('^([\\d/.-]+[ T][\\d]+:[\\d]+:[\\d]+( AM| PM)?)')
 STRIPPED_TIMESTAMP_REGEX = re.compile('^(.*?)[: /]*$')


### PR DESCRIPTION
Steam installed client produce a log line like the following:

[UnityCrossThreadLogger]-- Product List --

LOG_START_REGEX_TIMED will identify '--' as a timestamp, which then triggers an exception. This change just ensures the candidate timestamp starts with a number.