### PR TITLE
Process complete draft log entries immediately

### DIFF
--- a/src/cs/mtga-log-client/LogParser.cs
+++ b/src/cs/mtga-log-client/LogParser.cs
@@ -346,6 +346,51 @@ namespace mtga_log_client
             {
                 buffer.Add(line);
             }
+
+            if (BufferHasParseableJson())
+            {
+                HandleCompleteLogEntry();
+            }
+        }
+
+        private bool BufferHasParseableJson()
+        {
+            if (buffer.Count == 0)
+            {
+                return false;
+            }
+
+            String fullLog;
+            try
+            {
+                fullLog = String.Join("", buffer);
+            }
+            catch (OutOfMemoryException)
+            {
+                return false;
+            }
+
+            var dictMatch = JSON_DICT_REGEX.Match(fullLog);
+            if (!dictMatch.Success)
+            {
+                return false;
+            }
+
+            var listMatch = JSON_LIST_REGEX.Match(fullLog);
+            if (listMatch.Success && listMatch.Value.Length > dictMatch.Value.Length && listMatch.Index < dictMatch.Index)
+            {
+                return false;
+            }
+
+            try
+            {
+                ParseBlob(dictMatch.Value);
+                return true;
+            }
+            catch (JsonReaderException)
+            {
+                return false;
+            }
         }
 
         private void HandleCompleteLogEntry()

--- a/src/python/seventeenlands/mtga_follower.py
+++ b/src/python/seventeenlands/mtga_follower.py
@@ -415,6 +415,28 @@ class Follower:
         else:
             self.buffer.append(line)
 
+        # Some events (including one-line Draft.Notify payloads) are complete on this line.
+        # Parse them immediately instead of waiting for the next log-start boundary.
+        self.__maybe_handle_complete_log_entry_if_parseable()
+
+    def __maybe_handle_complete_log_entry_if_parseable(self) -> None:
+        if len(self.buffer) == 0:
+            return
+        if self.cur_log_time is None:
+            return
+
+        full_log = "".join(self.buffer)
+        match = JSON_START_REGEX.search(full_log)
+        if not match:
+            return
+
+        try:
+            self.json_decoder.raw_decode(full_log, match.start())
+        except json.JSONDecodeError:
+            return
+
+        self.__handle_complete_log_entry()
+
     def __handle_complete_log_entry(self) -> None:
         """Mark the current log message complete. Should be called when waiting for more log messages."""
         if len(self.buffer) == 0:


### PR DESCRIPTION
So that the pack info can be shown immediately consistently, without the need to make the pick first